### PR TITLE
Proper Shutdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .idea
+**.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,8 @@ dependencies = [
  "lib-wc",
  "reqwest",
  "scraper",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -276,6 +278,7 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+ "serde",
 ]
 
 [[package]]
@@ -1442,6 +1445,9 @@ name = "serde"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,12 @@ anyhow = "1.0.69"
 async-channel = "1.8.0"
 clap = { version = "4.1.6", features = ["derive"] }
 lib-wc = "0.1.14"
-dashmap = "5.4.0"
+dashmap = { version = "5.4.0", features = ["serde"] }
 reqwest = { version = "0.11", features = ["json"] }
 scraper = "0.14.0"
 tokio = { version = "1.25.0", features = ["full", "tracing"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 url = "2.3.1"
+serde = "1.0.152"
+serde_json = "1.0.93"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,3 @@ tokio = { version = "1.25.0", features = ["full", "tracing"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 url = "2.3.1"
-#console-subscriber = "0.1.8"

--- a/src/args.rs
+++ b/src/args.rs
@@ -19,11 +19,15 @@ pub struct Args {
     pub connections: u16,
 
     /// The number of processors to use. Processors interpret HTML and find the next URLs to crawl.
-    #[clap(short = 'p', long = "parsers", default_value_t = 100, value_parser = clap::value_parser ! (u16).range(1..))]
+    #[clap(short = 'p', long = "parsers", default_value_t = 16, value_parser = clap::value_parser ! (u16).range(1..))]
     pub processors: u16,
 
     /// The millisecond time interval between requests to a  particular domain.
     /// A low interval results in a high QPS which may get your IP blocked from certain sites.
     #[clap(short = 'r', long = "rate", default_value_t = 5000, value_parser = clap::value_parser ! (u64).range(1..))]
     pub interval: u64,
+
+    /// The file to write the index to. Optional.
+    #[clap(short = 'o', long = "output")]
+    pub output: Option<String>,
 }

--- a/src/index.rs
+++ b/src/index.rs
@@ -3,24 +3,35 @@ use tracing::info;
 
 pub struct Index {
     pub inner: DashMap<String, DashSet<String>>,
+    output: Option<String>,
 }
 
 impl Index {
-    pub fn new() -> Self {
+    pub fn new(output: Option<String>) -> Self {
         Self {
             inner: DashMap::new(),
+            output,
         }
     }
 }
 
 impl Drop for Index {
-    // TODO: write the index to a file
     fn drop(&mut self) {
-        info!("Dropping index...");
-        for e in self.inner.iter() {
-            info!("{} -> {}", e.key(), e.value().len());
-            for e in e.value().iter() {
-                info!("\t-> {}", e.key());
+        match self.output {
+            Some(ref path) => {
+                let mut file = std::fs::File::create(path).unwrap();
+                match serde_json::to_writer(&mut file, &self.inner) {
+                    Ok(_) => info!("Index written to {}", path),
+                    Err(e) => info!("Failed to write index to {}: {}", path, e),
+                }
+            }
+            None => {
+                for e in self.inner.iter() {
+                    info!("{} contained {} link(s)", e.key(), e.value().len());
+                    for e in e.value().iter() {
+                        info!("\t-> {}", e.key());
+                    }
+                }
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,8 +49,8 @@ impl Application {
         let rate_limiter: Arc<MultiRateLimiter<String>> =
             Arc::new(MultiRateLimiter::new(Duration::from_millis(args.interval)));
         let index = Arc::new(Index::new());
-        let (send_request, receive_request) = async_channel::bounded::<Request>(1000);
-        let (send_response, receive_response) = async_channel::bounded::<Response>(1000);
+        let (send_request, receive_request) = async_channel::unbounded();
+        let (send_response, receive_response) = async_channel::unbounded();
 
         send_request
             .send(Request::new(Url::parse(&args.target)?))
@@ -71,7 +71,6 @@ impl Application {
 
     fn initialize() -> Args {
         let args = Args::parse();
-        // console_subscriber::init();
         tracing_subscriber::fmt::init();
         info!("Starting up...");
         args

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -53,9 +53,7 @@ impl Processor {
         } = self;
 
         select! {
-           _ = shutdown.recv() => {
-                info!("Processor {} shutting down", id);
-            }
+           _ = shutdown.recv() => { }
            _ = do_work(receiver, sender, index) => { }
         }
     }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -1,7 +1,7 @@
 use crate::index::Index;
 use crate::messages::{Request, Response};
 use crate::urls::get_urls;
-use anyhow::{Context, Result};
+
 use async_channel::{Receiver, Sender};
 use dashmap::mapref::entry::Entry::{Occupied, Vacant};
 use dashmap::DashSet;
@@ -10,12 +10,12 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::Arc;
 use tokio::select;
-use tracing::{debug, info};
+use tracing::debug;
 use url::Url;
 
 pub struct Processor {
     /// The ID of the processor.
-    id: usize,
+    _id: usize,
     /// The channel to receive HTML from.
     receiver: Receiver<Response>,
     /// The channel to send URLs to crawl to.
@@ -35,7 +35,7 @@ impl Processor {
     ) -> Self {
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         Self {
-            id: COUNTER.fetch_add(1, SeqCst),
+            _id: COUNTER.fetch_add(1, SeqCst),
             receiver,
             sender,
             shutdown,
@@ -45,7 +45,7 @@ impl Processor {
 
     pub async fn run(&mut self) {
         let Processor {
-            id,
+            _id: _,
             receiver,
             sender,
             shutdown,
@@ -59,11 +59,7 @@ impl Processor {
     }
 }
 
-pub async fn do_work(
-    mut receiver: &Receiver<Response>,
-    mut sender: &Sender<Request>,
-    mut index: &Arc<Index>,
-) {
+pub async fn do_work(receiver: &Receiver<Response>, sender: &Sender<Request>, index: &Arc<Index>) {
     loop {
         let res = receiver.recv().await;
 

--- a/src/spider.rs
+++ b/src/spider.rs
@@ -1,6 +1,6 @@
 use crate::messages::{Request, Response};
 
-use anyhow::{Context, Result};
+use anyhow::Result;
 use async_channel::{Receiver, Sender};
 use lib_wc::sync::{MultiRateLimiter, ShutdownListener};
 use reqwest::Client;
@@ -13,7 +13,7 @@ use tracing::{debug, info};
 /// The spider which crawls the web.
 pub struct Spider {
     /// The ID of the spider.
-    id: usize,
+    _id: usize,
     /// The HTTP client.
     client: Client,
     /// The rate limiter.
@@ -35,7 +35,7 @@ impl Spider {
     ) -> Self {
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         Self {
-            id: COUNTER.fetch_add(1, SeqCst),
+            _id: COUNTER.fetch_add(1, SeqCst),
             client: Client::new(),
             rate_limiter,
             shutdown,
@@ -46,7 +46,7 @@ impl Spider {
 
     pub async fn run(&mut self) {
         let Spider {
-            id,
+            _id: _,
             client,
             rate_limiter,
             shutdown,
@@ -63,9 +63,9 @@ impl Spider {
 
 async fn do_work(
     client: &Client,
-    mut rate_limiter: &MultiRateLimiter<String>,
-    mut sender: &Sender<Response>,
-    mut receiver: &Receiver<Request>,
+    rate_limiter: &MultiRateLimiter<String>,
+    sender: &Sender<Response>,
+    receiver: &Receiver<Request>,
 ) {
     loop {
         let res = receiver.recv().await;

--- a/src/spider.rs
+++ b/src/spider.rs
@@ -55,9 +55,7 @@ impl Spider {
         } = self;
 
         select! {
-            _ = shutdown.recv() => {
-                info!("Spider {} shutting down", id);
-            }
+            _ = shutdown.recv() => { }
             _ = do_work(client, rate_limiter, sender, receiver) => { }
         }
     }

--- a/src/spider.rs
+++ b/src/spider.rs
@@ -54,62 +54,51 @@ impl Spider {
             receiver,
         } = self;
 
-        // TODO: split this up so that the program can terminate immediately (or use shutdown on every await...)
-        // select! {
-        //    _ = self.shutdown.recv() => { }
-        //    _ = do_work => { }
-        // }
+        select! {
+            _ = shutdown.recv() => {
+                info!("Spider {} shutting down", id);
+            }
+            _ = do_work(client, rate_limiter, sender, receiver) => { }
+        }
+    }
+}
 
-        loop {
-            info!("Spider {} is waiting for URL...", id);
+async fn do_work(
+    client: &Client,
+    mut rate_limiter: &MultiRateLimiter<String>,
+    mut sender: &Sender<Response>,
+    mut receiver: &Receiver<Request>,
+) {
+    loop {
+        let res = receiver.recv().await;
 
-            // Get the next URL to crawl
-            let res: Result<Request> = select! {
-                _ = shutdown.recv() => {
-                    info!("Shutting down spider {}...", id);
-                    return;
-                }
-                next_url = receiver.recv() => {
-                    next_url.context("Spider failed to receive URL")
-                }
-            };
+        let url = match res {
+            Ok(url) => url,
+            Err(e) => {
+                debug!("Spider failed to receive URL: {}", e);
+                continue;
+            }
+        };
 
-            let url = match res {
-                Ok(url) => url,
-                Err(e) => {
-                    debug!("Spider failed to receive URL: {}", e);
-                    continue;
-                }
-            };
+        let domain = match url.url.domain() {
+            Some(domain) => domain.to_string(),
+            _ => continue,
+        };
 
-            let domain = match url.url.domain() {
-                Some(domain) => domain.to_string(),
-                _ => continue,
-            };
+        let res = rate_limiter
+            .throttle(domain.to_string(), || crawl(client, url))
+            .await;
 
-            let res = select! {
-                res = rate_limiter.throttle(domain.to_string(), || Spider::crawl(client, url)) => {
-                    // Type hint so that the IDE doesn't complain :)
-                    let res: Result<Response> = res;
-                    res
-                },
-                _ = shutdown.recv() => {
-                    info!("Shutting down spider {}...", id);
-                    return;
-                }
-            };
-
-            if let Ok(response) = res {
-                if let Err(e) = sender.send(response).await {
-                    debug!("Spider failed to send response: {}", e);
-                }
+        if let Ok(response) = res {
+            if let Err(e) = sender.send(response).await {
+                debug!("Spider failed to send response: {}", e);
             }
         }
     }
+}
 
-    async fn crawl(mut client: &Client, req: Request) -> Result<Response> {
-        info!("Crawling {}", req.url);
-        let res = client.get(req.url.as_str()).send().await?;
-        Ok(Response::new(req.url, res))
-    }
+async fn crawl(client: &Client, req: Request) -> Result<Response> {
+    info!("Crawling {}", req.url);
+    let res = client.get(req.url.as_str()).send().await?;
+    Ok(Response::new(req.url, res))
 }

--- a/src/urls.rs
+++ b/src/urls.rs
@@ -5,26 +5,38 @@ use clap::Parser;
 use scraper::{Html, Selector};
 use url::Url;
 
+/// This is a mess and it works great :)
 pub fn get_urls(url: Url, html: &str) -> Result<Vec<String>> {
     let fragment = Html::parse_document(html);
     let selector =
         Selector::parse("a").map_err(|e| anyhow::anyhow!("Failed to parse selector: {}", e))?;
     let mut urls = Vec::new();
-
     for element in fragment.select(&selector) {
         if let Some(path) = element.value().attr("href") {
-            if path.starts_with('/') {
+            if path.starts_with('/') || path.starts_with("./") {
                 match get_base_url(&url) {
                     Some(base_url) => {
                         let url = join_urls(&base_url, path).context("Failed to join URLs")?;
                         urls.push(url.to_string());
                     }
-                    None => {
-                        urls.push(path.to_string());
-                    }
+                    None => {}
                 }
             } else {
-                urls.push(path.to_string());
+                match Url::parse(path) {
+                    Ok(_) => {
+                        urls.push(path.to_string());
+                    }
+                    Err(_) => match Url::parse(&url.to_string()) {
+                        Ok(url) => {
+                            let url = match join_urls(&url.to_string(), path) {
+                                Some(url) => url,
+                                None => continue,
+                            };
+                            urls.push(url.to_string());
+                        }
+                        Err(_) => {}
+                    },
+                }
             }
         }
     }
@@ -95,6 +107,29 @@ mod tests {
     }
 
     #[test]
+    fn test_get_urls2() -> Result<()> {
+        let url = "https://www.rust-lang.org";
+        let html = r#"
+            <html>
+                <body>
+                    <a href="./foo">Foo</a>
+                    <a href="/bar">Bar</a>
+                    <a href="https://www.rust-lang.org">Rust</a>
+                    <a href="https://www.rust-lang.org/foo">Rust</a>
+                </body>
+            </html>
+        "#;
+
+        let urls = get_urls(Url::parse(url)?, html).unwrap();
+        assert_eq!(urls.len(), 4);
+        assert_eq!(urls[0], "https://www.rust-lang.org/foo");
+        assert_eq!(urls[1], "https://www.rust-lang.org/bar");
+        assert_eq!(urls[2], "https://www.rust-lang.org");
+        assert_eq!(urls[3], "https://www.rust-lang.org/foo");
+        Ok(())
+    }
+
+    #[test]
     fn test_combine_relative_url() {
         let a = "https://en.wikipedia.org/wiki/Vienna";
         let b = "/wiki/Category:States_of_Austria";
@@ -111,6 +146,16 @@ mod tests {
 
         let url = join_urls(a, b).unwrap();
         let expected = "https://en.wikipedia.org/wiki/Category:States_of_Austria";
+        assert_eq!(url, expected);
+    }
+
+    #[test]
+    fn test_combine_relative_url3() {
+        let a = "https://www.netlify.com/";
+        let b = "./blog/2020/08/17/integrate-next.js-and-contentful/";
+
+        let url = join_urls(a, b).unwrap();
+        let expected = "https://www.netlify.com/blog/2020/08/17/integrate-next.js-and-contentful/";
         assert_eq!(url, expected);
     }
 

--- a/src/urls.rs
+++ b/src/urls.rs
@@ -1,11 +1,10 @@
 use anyhow::Context;
 use anyhow::Result;
-use clap::Parser;
 
 use scraper::{Html, Selector};
 use url::Url;
 
-/// This is a mess and it works great :)
+/// This is a mess and it works good enough :)
 pub fn get_urls(url: Url, html: &str) -> Result<Vec<String>> {
     let fragment = Html::parse_document(html);
     let selector =
@@ -14,28 +13,23 @@ pub fn get_urls(url: Url, html: &str) -> Result<Vec<String>> {
     for element in fragment.select(&selector) {
         if let Some(path) = element.value().attr("href") {
             if path.starts_with('/') || path.starts_with("./") {
-                match get_base_url(&url) {
-                    Some(base_url) => {
-                        let url = join_urls(&base_url, path).context("Failed to join URLs")?;
-                        urls.push(url.to_string());
-                    }
-                    None => {}
+                if let Some(base_url) = get_base_url(&url) {
+                    let url = join_urls(&base_url, path).context("Failed to join URLs")?;
+                    urls.push(url.to_string());
                 }
             } else {
                 match Url::parse(path) {
                     Ok(_) => {
                         urls.push(path.to_string());
                     }
-                    Err(_) => match Url::parse(&url.to_string()) {
-                        Ok(url) => {
-                            let url = match join_urls(&url.to_string(), path) {
-                                Some(url) => url,
+                    Err(_) => {
+                        if let Ok(url) = Url::parse(url.as_ref()) {
+                            match join_urls(url.as_ref(), path) {
+                                Some(url) => urls.push(url),
                                 None => continue,
                             };
-                            urls.push(url.to_string());
                         }
-                        Err(_) => {}
-                    },
+                    }
                 }
             }
         }
@@ -62,23 +56,6 @@ fn join_urls(base_url_string: &str, relative_url: &str) -> Option<String> {
         .join(relative_url)
         .ok()
         .map(|url| url.as_str().to_string())
-}
-
-pub fn normalize_url(url_str: &str) -> Option<String> {
-    let url_with_scheme = if !url_str.starts_with("http://") && !url_str.starts_with("https://") {
-        format!("https://{}", url_str)
-    } else {
-        url_str.to_string()
-    };
-
-    // Add a `/` to the end of the URL if it doesn't have one
-    let url_with_slash = if !url_with_scheme.ends_with('/') {
-        format!("{}/", url_with_scheme)
-    } else {
-        url_with_scheme
-    };
-
-    Some(url_with_slash)
 }
 
 #[cfg(test)]
@@ -157,17 +134,5 @@ mod tests {
         let url = join_urls(a, b).unwrap();
         let expected = "https://www.netlify.com/blog/2020/08/17/integrate-next.js-and-contentful/";
         assert_eq!(url, expected);
-    }
-
-    #[test]
-    fn test_normalize_url() {
-        let url1 = "https://farooq.dev";
-        let url2 = "farooq.dev";
-        let expected = "https://farooq.dev/";
-
-        let normalized_url1 = normalize_url(url1).unwrap();
-        assert_eq!(normalized_url1, expected);
-        let normalized_url2 = normalize_url(url2).unwrap();
-        assert_eq!(normalized_url2, expected);
     }
 }


### PR DESCRIPTION
## Summary

This PR touches the following:
- splitting processor & spider work into separate futures
- task cancellation upon shutdown
- persisting the index to disk (using `serde` and `serde_json`)
- optional arg to provide a filename
- removing bounds on the async channels (maybe this is a bad idea!)
- expanding URL parsing to recognize more patterns

---

Shutdown is not used to preserve any in-flight requests from the spiders. Instead, it is used to make sure that the program exits properly such that the `Drop` implementation for the `Index` is used